### PR TITLE
docs: exclude dollar sign from set of allowed characters for passwords and salts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,13 @@ provider "htpasswd" {
 
 ```hcl
 resource "random_password" "password" {
-  length = 30
+  length  = 30
+  special = false
 }
 
 resource "random_password" "salt" {
-  length = 8
+  length  = 8
+  special = false
 }
 
 resource "htpasswd_password" "hash" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,13 +19,15 @@ provider "htpasswd" {
 
 ```hcl
 resource "random_password" "password" {
-  length  = 30
-  special = false
+  length           = 30
+  special          = true
+  special_override = "!@#%&*()-_=+[]{}<>:?"
 }
 
 resource "random_password" "salt" {
-  length  = 8
-  special = false
+  length           = 8
+  special          = true
+  special_override = "!@#%&*()-_=+[]{}<>:?"
 }
 
 resource "htpasswd_password" "hash" {

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -6,12 +6,17 @@ Generate hashes of provided password string
 
 ```hcl
 resource "random_password" "password" {
-  length = 30
+  length           = 30
+  special          = true
+  special_override = "!@#%&*()-_=+[]{}<>:?"
 }
 
 resource "random_password" "salt" {
-  length = 8
+  length           = 8
+  special          = true
+  special_override = "!@#%&*()-_=+[]{}<>:?"
 }
+
 resource "htpasswd_password" "hash" {
   password = random_password.password.result
   salt     = random_password.salt.result


### PR DESCRIPTION
Your docs for salts and passwords currently supports *any* special characters. Particularly for the salt, this causes issues, because a salt including "$" will break the encoding of apr1 secret.

For an 8 byte salt, the chances of it including a dollar sign are small but not zero, and exactly this happened to us, breaking downstream at the validation of the password.

This PR refines the documentation to explicitly exclude $ from the set of special characters included in the example password and salt.

