### PR TITLE
feat: add artifacts for the *_386 platforms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,12 @@ builds:
     - darwin
   goarch:
     - amd64
+    - 386
     - arm
     - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'    
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Hello @loafoe, thank you for your great work!

I've recently tried to use this provider in my environment and fount out that it's missing a release for the linux_386 platform.

Can we add a release for linux_386 platform?