### PR TITLE
Expose insecure SHA-1 algorithm

### DIFF
--- a/docs/ephemeral-resources/password.md
+++ b/docs/ephemeral-resources/password.md
@@ -56,6 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `apr1` - (Computed) The APR1-MD5 hash of the password.
 * `bcrypt` - (Computed) The bcrypt hash of the password.
+* `sha1` - (Computed) the SHA-1 hash of the password. This algorithm is **insecure** by today's standards.
 * `sha256` - (Computed) The SHA-256 hash of the password (hex encoded).
 * `sha512` - (Computed) The SHA-512 crypt hash of the password.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,11 @@ output "bcrypt_hash" {
   value = htpasswd_password.hash.bcrypt
 }
 
+output "sha1_hash" {
+  # This algorithm is insecure by today's standards.
+  value = htpasswd_password.hash.sha1
+}
+
 output "sha256_hash" {
   value = htpasswd_password.hash.sha256
 }

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -64,5 +64,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `apr1` - (Computed) The apr1 hash of the password
 * `bcrypt` - (Computed) the bcrypt hash of the password
+* `sha1` - (Computed) the SHA-1 hash of the password. This algorithm is **insecure** by today's standards.
 * `sha256` - (Computed) the SHA-256 hash of the password
 * `sha512` - (Computed) the SHA-512 hash of the password

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -64,6 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `apr1` - (Computed) The apr1 hash of the password
 * `bcrypt` - (Computed) the bcrypt hash of the password
-* `sha1` - (Computed) the SHA-1 hash of the password. This algorithm is **insecure** by today's standards.
+* `sha1` - (Computed) the SHA-1 hash of the password. This algorithm is
+  **insecure** by today's standards.
 * `sha256` - (Computed) the SHA-256 hash of the password
 * `sha512` - (Computed) the SHA-512 hash of the password

--- a/htpasswd/ephemeral_password.go
+++ b/htpasswd/ephemeral_password.go
@@ -21,6 +21,7 @@ type PasswordEphemeralModel struct {
 	Salt     types.String `tfsdk:"salt"`
 	Apr1     types.String `tfsdk:"apr1"`
 	Bcrypt   types.String `tfsdk:"bcrypt"`
+	Sha1     types.String `tfsdk:"sha1"`
 	Sha256   types.String `tfsdk:"sha256"`
 	Sha512   types.String `tfsdk:"sha512"`
 }
@@ -57,6 +58,10 @@ func (r *PasswordEphemeral) Schema(_ context.Context, _ ephemeral.SchemaRequest,
 				Computed:    true,
 				Description: "Bcrypt hash of the password",
 			},
+			"sha1": schema.StringAttribute{
+				Computed:    true,
+				Description: "SHA1 crypt hash of the password (insecure)",
+			},
 			"sha256": schema.StringAttribute{
 				Computed:    true,
 				Description: "SHA-256 hash of the password (hex encoded)",
@@ -92,10 +97,12 @@ func (r *PasswordEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest,
 		return
 	}
 
+	sha1hash := sha1Crypt(password)
 	sha512hash := sha512Crypt(password, salt)
 
 	data.Bcrypt = types.StringValue(string(bcryptHash))
 	data.Apr1 = types.StringValue(apr1Hash)
+	data.Sha1 = types.StringValue(sha1hash)
 	data.Sha512 = types.StringValue(sha512hash)
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)

--- a/htpasswd/ephemeral_password_test.go
+++ b/htpasswd/ephemeral_password_test.go
@@ -58,8 +58,9 @@ ephemeral "htpasswd_password" "%s" {
 locals {
   apr1_hash   = ephemeral.htpasswd_password.%s.apr1
   bcrypt_hash = ephemeral.htpasswd_password.%s.bcrypt
+  sha1_hash   = ephemeral.htpasswd_password.%s.sha1
   sha256_hash = ephemeral.htpasswd_password.%s.sha256
   sha512_hash = ephemeral.htpasswd_password.%s.sha512
 }
-`, name, password, salt, name, name, name, name)
+`, name, password, salt, name, name, name, name, name)
 }

--- a/htpasswd/resource_password.go
+++ b/htpasswd/resource_password.go
@@ -2,9 +2,11 @@ package htpasswd
 
 import (
 	"context"
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -28,6 +30,7 @@ type PasswordModel struct {
 	Salt     types.String `tfsdk:"salt"`
 	Apr1     types.String `tfsdk:"apr1"`
 	Bcrypt   types.String `tfsdk:"bcrypt"`
+	Sha1     types.String `tfsdk:"sha1"`
 	Sha256   types.String `tfsdk:"sha256"`
 	Sha512   types.String `tfsdk:"sha512"`
 }
@@ -77,6 +80,10 @@ func (r *PasswordResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 				Description: "Bcrypt hash of the password",
 			},
+			"sha1": schema.StringAttribute{
+				Computed:    true,
+				Description: "SHA1 crypt hash of the password (insecure)",
+			},
 			"sha256": schema.StringAttribute{
 				Computed:    true,
 				Description: "SHA-256 hash of the password (hex encoded)",
@@ -113,16 +120,15 @@ func (r *PasswordResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	sha512hash := sha512Crypt(password, salt)
-
-	h := sha256.New()
-	h.Write([]byte(salt + password))
-	sha256Hash := hex.EncodeToString(h.Sum(nil))
+	sha256Hash := sha256Crypt(password, salt)
+	sha1Hash := sha1Crypt(password)
 
 	data.ID = types.StringValue(fmt.Sprintf("PW%x", string(bcryptHash)))
 	data.Bcrypt = types.StringValue(string(bcryptHash))
 	data.Apr1 = types.StringValue(apr1Hash)
-	data.Sha512 = types.StringValue(sha512hash)
+	data.Sha1 = types.StringValue(sha1Hash)
 	data.Sha256 = types.StringValue(sha256Hash)
+	data.Sha512 = types.StringValue(sha512hash)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -211,6 +217,23 @@ func (v *saltValidator) ValidateString(_ context.Context, req validator.StringRe
 			break
 		}
 	}
+}
+
+// The SHA-1 algorithm doesn't use any salt and is considered insecure.
+func sha1Crypt(password string) string {
+	const prefix = "{SHA}"
+
+	h := sha1.New()
+	h.Write([]byte(password))
+	hash := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return prefix + hash
+}
+
+func sha256Crypt(password, salt string) string {
+	h := sha256.New()
+	h.Write([]byte(salt + password))
+	hash := hex.EncodeToString(h.Sum(nil))
+	return hash
 }
 
 // sha512Crypt implements the SHA-512 crypt algorithm as specified in
@@ -367,4 +390,3 @@ func sha512Crypt(password, salt string) string {
 
 	return prefix + salt + "$" + encoded
 }
-

--- a/htpasswd/resource_password_test.go
+++ b/htpasswd/resource_password_test.go
@@ -17,6 +17,7 @@ func TestAccResourcePassword_Complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("htpasswd_password.test_1", "password", "secret123"),
 					resource.TestCheckResourceAttr("htpasswd_password.test_1", "salt", "saltySal"),
+					resource.TestCheckResourceAttrSet("htpasswd_password.test_1", "sha1"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_1", "sha256"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_1", "sha512"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_1", "apr1"),
@@ -24,6 +25,9 @@ func TestAccResourcePassword_Complete(t *testing.T) {
 					// Check apr1 format: should start with $apr1$saltySal$
 					resource.TestMatchResourceAttr("htpasswd_password.test_1", "apr1",
 						regexp.MustCompile(`^\$apr1\$saltySal\$.+`)),
+					// Check sha1 format: should start with {SHA}
+					resource.TestMatchResourceAttr("htpasswd_password.test_1", "sha1",
+						regexp.MustCompile(`^{SHA}.+`)),
 					// Check sha512 format: should start with $6$saltySal$
 					resource.TestMatchResourceAttr("htpasswd_password.test_1", "sha512",
 						regexp.MustCompile(`^\$6\$saltySal\$.+`)),
@@ -37,6 +41,7 @@ func TestAccResourcePassword_Complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("htpasswd_password.test_2", "password", "1234567890abcdefghijklmnopqrstuvwxyz"),
 					resource.TestCheckResourceAttr("htpasswd_password.test_2", "salt", "12341234"),
+					resource.TestCheckResourceAttrSet("htpasswd_password.test_2", "sha1"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_2", "sha256"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_2", "sha512"),
 					resource.TestCheckResourceAttrSet("htpasswd_password.test_2", "apr1"),
@@ -44,6 +49,9 @@ func TestAccResourcePassword_Complete(t *testing.T) {
 					// Check apr1 format: should start with $apr1$12341234$
 					resource.TestMatchResourceAttr("htpasswd_password.test_2", "apr1",
 						regexp.MustCompile(`^\$apr1\$12341234\$.+`)),
+					// Check sha1 format: should start with {SHA}
+					resource.TestMatchResourceAttr("htpasswd_password.test_2", "sha1",
+						regexp.MustCompile(`^{SHA}.+`)),
 					// Check sha512 format: should start with $6$12341234$
 					resource.TestMatchResourceAttr("htpasswd_password.test_2", "sha512",
 						regexp.MustCompile(`^\$6\$12341234\$.+`)),


### PR DESCRIPTION
This also exposes the SHA-1 algorithm: although it's not considered secure, it may still be used by other applications consuming credentials.

I marked that it's insecure using the terminology used on [the Apache website](https://httpd.apache.org/docs/current/programs/htpasswd.html).

I verified it works as expected using the following:

```hcl
locals {
  user     = "foo"
  password = "bar"
}

resource "htpasswd_password" "test" {
  password = local.password
  salt     = "23456789"
}

resource "local_file" "test" {
  # Trailing new line is important!
  content  = "${local.user}:${htpasswd_password.test.sha1}\n"
  filename = "credentials.htpasswd"
}
```

Then checking I can authenticate against the file with:

```
$ htpasswd -vb credentials.htpasswd foo bar
Password for user foo correct.

$ htpasswd -vb credentials.htpasswd foo baz
password verification failed
```

It's also implemented with the ephemeral resource.

Closes: https://github.com/loafoe/terraform-provider-htpasswd/issues/100